### PR TITLE
Remplacement de "reines" par "dames"

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ court possible ? Ce problème d'optimisation aux applications innombrables nous
 permet d'introduire la notion de complexité pour classer les problèmes, et la
 recherche de solution optimale ou approchée.
 
-## Les 8 reines (en cours de développement)
+## Les 8 dames (en cours de développement)
 
-Comment placer huit reines sur un échiquier de sorte qu'aucune ne soit sur la
+Comment placer huit dames sur un échiquier de sorte qu'aucune ne soit sur la
 trajectoire d'une autre ? La résolution de ce problème nous permet d'introduire
 les notions de récursivité et de back-tracking.
 

--- a/fiches-uniques/dames.tex
+++ b/fiches-uniques/dames.tex
@@ -1,8 +1,8 @@
-\chapter*{Les 8 reines}
+\chapter*{Les 8 dames}
 
-On dispose d'un échiquier de dimension $8 \times 8$, et de $8$ reines disposées
-sur celui-ci. Sachant qu'aux échecs une reine peut se déplacer en ligne, en
-colonne ou en diagonale, \textbf{comment disposer disposer les reines sur
+On dispose d'un échiquier de dimension $8 \times 8$, et de $8$ dames disposées
+sur celui-ci. Sachant qu'aux échecs une dames peut se déplacer en ligne, en
+colonne ou en diagonale, \textbf{comment disposer disposer les dames sur
   l'échiquier de sorte qu'aucune ne soit sur la trajectoire d'une autre ?} Et
 comment trouver toutes les solutions possibles à ce problème ?
 
@@ -31,7 +31,7 @@ comment trouver toutes les solutions possibles à ce problème ?
 \encart{Matériel}{
   \begin{itemize}
   \item Un plateau quadrillé (on peut le dessiner sur une feuille) ;
-  \item 8 pièces à poser sur le plateau pour représenter les reines.
+  \item 8 pièces à poser sur le plateau pour représenter les dames.
   \end{itemize}
 }
 
@@ -40,7 +40,7 @@ comment trouver toutes les solutions possibles à ce problème ?
 \section*{Dimension du problème}
 
 Pour se faire une idée de la dimension du problème, calculons le nombre de
-configurations possibles pour 8 reines sur un échiquier :
+configurations possibles pour 8 dames sur un échiquier :
 
 \begin{equation}
     \frac{64!}{(64-8)! \times 8!} = 4426165368
@@ -58,9 +58,9 @@ allons donc devoir procéder d'une manière plus intelligente ...
 Une manière de construire une solution est de procéder par étapes.
 
 1 démarrer d'un échiquier vide
-2 ajouter une reine sur une case libre
+2 ajouter une dames sur une case libre
 3 recommencer 2 tant que c'est possible
-4 si on atteint 8 reines, on a trouvé une solution
+4 si on atteint 8 dames, on a trouvé une solution
 
 % FIXME l'idée à faire passer : solution partielle, on ajoute un élément pour créer une nouvelle solution.
 

--- a/fiches-uniques/dames.tex
+++ b/fiches-uniques/dames.tex
@@ -1,7 +1,7 @@
 \chapter*{Les 8 dames}
 
 On dispose d'un échiquier de dimension $8 \times 8$, et de $8$ dames disposées
-sur celui-ci. Sachant qu'aux échecs une dames peut se déplacer en ligne, en
+sur celui-ci. Sachant qu'aux échecs une dame peut se déplacer en ligne, en
 colonne ou en diagonale, \textbf{comment disposer disposer les dames sur
   l'échiquier de sorte qu'aucune ne soit sur la trajectoire d'une autre ?} Et
 comment trouver toutes les solutions possibles à ce problème ?
@@ -58,7 +58,7 @@ allons donc devoir procéder d'une manière plus intelligente ...
 Une manière de construire une solution est de procéder par étapes.
 
 1 démarrer d'un échiquier vide
-2 ajouter une dames sur une case libre
+2 ajouter une dame sur une case libre
 3 recommencer 2 tant que c'est possible
 4 si on atteint 8 dames, on a trouvé une solution
 


### PR DESCRIPTION
Si on parle du jeu d'échecs, il n'existe pas de pièce appelée "reine".
Source : http://www.echecs.asso.fr/LivreArbitre/110.pdf